### PR TITLE
Fix FixedScrollMetrics

### DIFF
--- a/lib/src/floating_search_bar_scroll_notifier.dart
+++ b/lib/src/floating_search_bar_scroll_notifier.dart
@@ -41,6 +41,7 @@ class FloatingSearchBarScrollNotifier extends StatelessWidget {
               maxScrollExtent: metrics.maxScrollExtent,
               minScrollExtent: metrics.minScrollExtent,
               viewportDimension: metrics.viewportDimension,
+              devicePixelRatio: metrics.devicePixelRatio,
             );
           }
 


### PR DESCRIPTION
Resolved missing param: 


```
../../../.pub-cache/git/material_floating_search_bar-e71c90e759f7b6bea64f846f5597c0a7734bbfe7/lib/src/floating_search_bar_scroll_notifier.dart:38:41: Error: Required named parameter 'devicePixelRatio' must be provided.
            metrics = FixedScrollMetrics(
                                        ^
flutter/packages/flutter/lib/src/widgets/scroll_metrics.dart:140:3: Context: Found this candidate, but the arguments don't match.
  FixedScrollMetrics({
  ^^^^^^^^^^^^^^^^^^
```