### PR TITLE
Constrain Flutter version

### DIFF
--- a/lib/src/floating_search_bar_scroll_notifier.dart
+++ b/lib/src/floating_search_bar_scroll_notifier.dart
@@ -41,6 +41,7 @@ class FloatingSearchBarScrollNotifier extends StatelessWidget {
               maxScrollExtent: metrics.maxScrollExtent,
               minScrollExtent: metrics.minScrollExtent,
               viewportDimension: metrics.viewportDimension,
+              devicePixelRatio: metrics.devicePixelRatio,
             );
           }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ repository: https://github.com/bxqm/material_floating_search_bar
 
 environment:
   sdk: '>=2.19.2 <3.0.0'
+  flutter: ">=3.8.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Further to previous pull request: https://github.com/lrorpilla/material_floating_search_bar/pull/5

Since the `devicePixelRatio` param was not added until:
https://github.com/flutter/flutter/commit/fdc25a170087ac2308fb5486e9cf76ef62f57b5a

The package needs to be constrained to a Flutter version which includes this param.